### PR TITLE
Queries

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -20,10 +20,11 @@ const ctxName = ctxKey("restfulRequestData")
 // Usually it is available via lambda function context and provides data for header manipulation.
 // Often accessed as restful.L(ctx).
 type Lambda struct {
-	r     *http.Request
-	w     http.ResponseWriter
-	trace *trace
-	vars  map[string]string
+	r      *http.Request
+	w      http.ResponseWriter
+	status int
+	trace  *trace
+	vars   map[string]string
 }
 
 func newLambda(w http.ResponseWriter, r *http.Request, vars map[string]string) *Lambda {
@@ -94,6 +95,14 @@ func (l *Lambda) RequestHeaderGet(header string) string {
 // RequestHeaderValues returns all the values of header in received HTTP request.
 func (l *Lambda) RequestHeaderValues(header string) []string {
 	return l.r.Header.Values(header)
+}
+
+// ResponseStatus sets HTTP status code to be sent.
+// Use that if you want to set positive (non-error) status code.
+//    restful.L(ctx).ResponseStatus(http.StatusAccepted)
+// Has no effect if lambda returns a non-nil error. In such case status is taken from the error (see restful.NewError), or 500 is returned.
+func (l *Lambda) ResponseStatus(status int) {
+	l.status = status
 }
 
 // ResponseHeaderSet sets an HTTP header to the response to be sent.

--- a/ctx.go
+++ b/ctx.go
@@ -57,7 +57,14 @@ func (l *Lambda) RequestURL() *url.URL {
 }
 
 // RequestPathParameters returns all the path parameters of received HTTP request.
+//
+// Deprecated: Use RequestVars instead.
 func (l *Lambda) RequestPathParameters() map[string]string {
+	return l.RequestVars()
+}
+
+// RequestVars returns all the named path or query parameters of received HTTP request.
+func (l *Lambda) RequestVars() map[string]string {
 	if l.vars == nil {
 		l.vars = make(map[string]string)
 	}

--- a/data.go
+++ b/data.go
@@ -89,6 +89,9 @@ func getJSONData(headers http.Header, ioBody io.ReadCloser, maxBytes int, data i
 		return err
 	}
 	if len(body) == 0 {
+		if request {
+			return NewError(nil, http.StatusBadRequest, "body expected")
+		}
 		return nil
 	}
 

--- a/error.go
+++ b/error.go
@@ -64,15 +64,15 @@ func (e *restError) Unwrap() error {
 // NewError creates a new error that contains HTTP status code.
 // Coupling HTTP status code to error makes functions return values clean. And controls what Lambda sends on errors.
 //
-// if err != nil {return restful.NewError(err, http.StatusBadRequest)}
+//    if err != nil {return restful.NewError(err, http.StatusBadRequest)}
 //
 // Parameter description is optional, caller may provide extra description, appearing at the beginning of the error string.
 //
-// if err != nil {return restful.NewError(err, http.StatusBadRequest, "bad data")}
+//    if err != nil {return restful.NewError(err, http.StatusBadRequest, "bad data")}
 //
 // Parameter err may be nil, if there is no error to wrap or original error text is better not to be propagated.
 //
-// if err != nil {return restful.NewError(nil, http.StatusBadRequest, "bad data")}
+//    if err != nil {return restful.NewError(nil, http.StatusBadRequest, "bad data")}
 func NewError(err error, statusCode int, description ...string) error {
 	return &restError{err: err, statusCode: statusCode, problemDetails: ProblemDetails{Detail: strings.Join(description, " ")}}
 }

--- a/lambda_status_test.go
+++ b/lambda_status_test.go
@@ -22,7 +22,12 @@ func ret1(ctx context.Context) error {
 	return nil
 }
 
-func ret2(ctx context.Context) (int, error) {
+func ret2p(ctx context.Context) (*strType, error) {
+	L(ctx).ResponseStatus(202)
+	return nil, nil
+}
+
+func ret2i(ctx context.Context) (int, error) {
 	L(ctx).ResponseStatus(202)
 	return 42, nil
 }
@@ -33,7 +38,8 @@ func TestStatus(t *testing.T) {
 	r := NewRouter()
 	r.HandleFunc("/ret0", ret0)
 	r.HandleFunc("/ret1", ret1)
-	r.HandleFunc("/ret2", ret2)
+	r.HandleFunc("/ret2p", ret2p)
+	r.HandleFunc("/ret2i", ret2i)
 
 	{
 		req, err := http.NewRequest("GET", "/ret0", nil)
@@ -41,6 +47,8 @@ func TestStatus(t *testing.T) {
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 		assert.Equal(202, rr.Code)
+		assert.Equal(0, rr.Body.Len())
+		assert.Equal("", rr.Header().Get("content-type"))
 	}
 	{
 		req, err := http.NewRequest("GET", "/ret1", nil)
@@ -48,13 +56,25 @@ func TestStatus(t *testing.T) {
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 		assert.Equal(202, rr.Code)
+		assert.Equal(0, rr.Body.Len())
+		assert.Equal("", rr.Header().Get("content-type"))
 	}
 	{
-		req, err := http.NewRequest("GET", "/ret2", nil)
+		req, err := http.NewRequest("GET", "/ret2p", nil)
+		assert.NoError(err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		assert.Equal(202, rr.Code)
+		assert.Equal(0, rr.Body.Len())
+		assert.Equal("", rr.Header().Get("content-type"))
+	}
+	{
+		req, err := http.NewRequest("GET", "/ret2i", nil)
 		assert.NoError(err)
 		rr := httptest.NewRecorder()
 		r.ServeHTTP(rr, req)
 		assert.Equal(202, rr.Code)
 		assert.Equal("42", rr.Body.String())
+		assert.Equal("application/json", rr.Header().Get("content-type"))
 	}
 }

--- a/lambda_status_test.go
+++ b/lambda_status_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Nokia
+// Licensed under the BSD 3-Clause License.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package restful
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ret0(ctx context.Context) {
+	L(ctx).ResponseStatus(202)
+}
+
+func ret1(ctx context.Context) error {
+	L(ctx).ResponseStatus(202)
+	return nil
+}
+
+func ret2(ctx context.Context) (int, error) {
+	L(ctx).ResponseStatus(202)
+	return 42, nil
+}
+
+func TestStatus(t *testing.T) {
+	assert := assert.New(t)
+
+	r := NewRouter()
+	r.HandleFunc("/ret0", ret0)
+	r.HandleFunc("/ret1", ret1)
+	r.HandleFunc("/ret2", ret2)
+
+	{
+		req, err := http.NewRequest("GET", "/ret0", nil)
+		assert.NoError(err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		assert.Equal(202, rr.Code)
+	}
+	{
+		req, err := http.NewRequest("GET", "/ret1", nil)
+		assert.NoError(err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		assert.Equal(202, rr.Code)
+	}
+	{
+		req, err := http.NewRequest("GET", "/ret2", nil)
+		assert.NoError(err)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		assert.Equal(202, rr.Code)
+		assert.Equal("42", rr.Body.String())
+	}
+}

--- a/mux_route.go
+++ b/mux_route.go
@@ -65,6 +65,15 @@ func (route *Route) PathPrefix(pathTemplate string) *Route {
 	return route
 }
 
+// Queries adds a matcher for URL query values.
+//     route.Queries("id", "{id:[0-9]+}")
+// The odd (1st, 3rd, etc) string is the query parameter.
+// The even (2nd, 4th, etc) string is the variable name and optional regex pattern.
+func (route *Route) Queries(pairs ...string) *Route {
+	route.route = route.route.Queries(pairs...)
+	return route
+}
+
 // Schemes adds a matcher for URL schemes.
 func (route *Route) Schemes(schemes ...string) *Route {
 	route.route = route.route.Schemes(schemes...)

--- a/mux_router.go
+++ b/mux_router.go
@@ -93,6 +93,14 @@ func (r *Router) PathPrefix(pathTemplate string) *Route {
 	return newRoute(r.router.PathPrefix(pathTemplate), r.monitors)
 }
 
+// Queries registers a new route with a matcher for URL query values.
+//     router.Queries("id", "{id:[0-9]+}")
+// The odd (1st, 3rd, etc) string is the query parameter.
+// The even (2nd, 4th, etc) string is the variable name and optional regex pattern.
+func (r *Router) Queries(pairs ...string) *Route {
+	return newRoute(r.router.Queries(pairs...), r.monitors)
+}
+
 // Schemes registers a new route with a matcher for URL schemes.
 func (r *Router) Schemes(schemes ...string) *Route {
 	return newRoute(r.router.Schemes(schemes...), r.monitors)


### PR DESCRIPTION
* `Router/Route.Queries()`
* Lambda `ResponseStatus()`
* Lambda fails (400) if data is expected, but body is not received.
* Lambda wrapper refact: Smaller functions instead of a monolithic one. 