### PR TITLE
make invalidParams JSON comply with 3GPP standards

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -278,7 +278,7 @@ func TestCookieJar(t *testing.T) {
 	ctx := context.Background()
 	jar, _ := cookiejar.New(nil)
 	client := NewClient().Root(srv.URL).SetJar(jar)
-	jar.SetCookies(srvURL, []*http.Cookie{&http.Cookie{Name: "token", Value: "secret", MaxAge: 10}})
+	jar.SetCookies(srvURL, []*http.Cookie{{Name: "token", Value: "secret", MaxAge: 10}})
 	err := client.Get(ctx, "/", nil)
 	assert.NoError(err)
 	assert.Equal("new secret", client.Jar().Cookies(srvURL)[0].Value)
@@ -339,7 +339,7 @@ func TestGet500Details(t *testing.T) {
 			ProblemDetails{
 				Title:         "title",
 				Detail:        "descr",
-				InvalidParams: map[string]string{"param1": "error text"},
+				InvalidParams: []InvalidParam{{"param1", "error text"}},
 			})
 
 		SendResp(w, r, err, nil)
@@ -350,7 +350,7 @@ func TestGet500Details(t *testing.T) {
 	err := c.Get(context.Background(), srv.URL, nil)
 	assert.Error(err)
 	assert.NotEmpty(err.Error())
-	assert.Equal("{\"title\":\"title\",\"detail\":\"descr\",\"invalidParams\":{\"param1\":\"error text\"}}", err.Error())
+	assert.Equal(`{"title":"title","detail":"descr","invalidParams":[{"param":"param1","reason":"error text"}]}`, err.Error())
 	assert.Equal(http.StatusInternalServerError, GetErrStatusCode(err))
 	assert.Equal(http.StatusInternalServerError, GetErrStatusCodeElse(err, 0))
 }

--- a/error.go
+++ b/error.go
@@ -20,7 +20,7 @@ type restError struct {
 // InvalidParam is the common InvalidParam object defined in 3GPP TS 29.571
 type InvalidParam struct {
 	Param  string `json:"param"`
-	Reason string `json:"reason"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // ProblemDetails is a structure defining fields for RFC 7807 error responses.

--- a/error.go
+++ b/error.go
@@ -17,15 +17,21 @@ type restError struct {
 	problemDetails ProblemDetails
 }
 
+// InvalidParam is the common InvalidParam object defined in 3GPP TS 29.571
+type InvalidParam struct {
+	Param  string `json:"param"`
+	Reason string `json:"reason"`
+}
+
 // ProblemDetails is a structure defining fields for RFC 7807 error responses.
 type ProblemDetails struct {
-	Type          string            `json:"type,omitempty"`
-	Title         string            `json:"title,omitempty"`
-	Detail        string            `json:"detail,omitempty"`
-	Cause         string            `json:"cause,omitempty"`
-	Instance      string            `json:"instance,omitempty"`
-	Status        int               `json:"status,omitempty"`
-	InvalidParams map[string]string `json:"invalidParams,omitempty"`
+	Type          string         `json:"type,omitempty"`
+	Title         string         `json:"title,omitempty"`
+	Detail        string         `json:"detail,omitempty"`
+	Cause         string         `json:"cause,omitempty"`
+	Instance      string         `json:"instance,omitempty"`
+	Status        int            `json:"status,omitempty"`
+	InvalidParams []InvalidParam `json:"invalidParams,omitempty"`
 }
 
 // String makes string of ProblemDetails.

--- a/server_test.go
+++ b/server_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGracefulZero(t *testing.T) {
-	s := NewServer().Graceful(0)
+	s := NewServer().Graceful(0).Addr(":8080")
 	go func() {
 		time.Sleep(time.Millisecond)
 		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)


### PR DESCRIPTION
In 3GPP TS 29.571 InvalidParams is defined as an array of {param, reason}