### PR TITLE
Client.HTTPS() applied to SetClientCredentialAuth.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -504,7 +504,22 @@ func TestCtxCancelBefore(t *testing.T) {
 }
 
 func TestSetClientCredentialAuthDown(t *testing.T) {
-	client := NewClient().SetClientCredentialAuth("id", "secret", "https://0.0.0.0:1")
-	err := client.Get(context.Background(), "https://127.0.0.1", nil)
+	client := NewClient().HTTPS(nil).SetClientCredentialAuth("id", "secret", "https://0.0.0.0:1")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := client.Get(ctx, "https://127.0.0.1", nil)
 	assert.Contains(t, err.Error(), "0.0.0.0:1")
+}
+
+func TestSetClientCredentialAuthDownAllowedTarget(t *testing.T) {
+	client := NewClient().HTTPS(&HTTPSConfig{AllowedHTTPHosts: []string{"0.0.0.0"}}).SetClientCredentialAuth("id", "secret", "http://0.0.0.0:1")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := client.Get(ctx, "https://127.0.0.1", nil)
+	assert.Contains(t, err.Error(), "0.0.0.0:1")
+}
+
+func TestSetClientCredentialNotAllowedTarget(t *testing.T) {
+	client := NewClient().HTTPS(nil).SetClientCredentialAuth("id", "secret", "http://0.0.0.0:1")
+	assert.NotNil(t, client)
 }

--- a/doc/client.md
+++ b/doc/client.md
@@ -54,6 +54,19 @@ if err != nil {
 
 ## HTTPS
 
+### Check URL
+
+It is possible to disable cleartext HTTP entirely or enable toward certain targets only.
+
+```go
+clientNoHTTP := restful.NewClient().HTTPS(nil)
+clientNoHTTPUnlessTest := restful.NewClient().HTTPS(&HTTPSConfig{AllowedHTTPHosts: []string{"test.server"}})
+clientNoHTTPUnlessLocal := restful.NewClient().HTTPS(&HTTPSConfig{AllowLocalhostHTTP: true})
+```
+
+It is up to the design paradigm whether to allow cleartext traffic for non-test targets.
+According to service mesh pattern transport issues, including encryption algorithms, do not belong to the business logic.
+
 ### OS cert pool
 
 HTTPS works out of box. Certs are loaded from OS cert pool without further ado.


### PR DESCRIPTION
Client.HTTPS() applied to SetClientCredentialAuth.