### PR TITLE
AddlambdaToContext function

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -29,3 +29,8 @@ func NewRequestCtx(w http.ResponseWriter, r *http.Request) context.Context {
 func L(ctx context.Context) *lambda.Lambda {
 	return lambda.L(ctx)
 }
+
+// AddLambdaToContext will return the context with value of Lambda
+func AddLambda(ctx context.Context, l *lambda.Lambda) context.Context {
+	return lambda.AddLambdaToContext(ctx, l)
+}

--- a/ctx.go
+++ b/ctx.go
@@ -31,6 +31,7 @@ func L(ctx context.Context) *lambda.Lambda {
 }
 
 // AddLambdaToContext will return the context with value of Lambda
+// Useful if a new goroutine is created with new context, but it is related to the original Context.
 func AddLambda(ctx context.Context, l *lambda.Lambda) context.Context {
 	return lambda.AddLambdaToContext(ctx, l)
 }

--- a/lambda/ctx.go
+++ b/lambda/ctx.go
@@ -142,3 +142,8 @@ func (l *Lambda) ResponseHeaderAddAs(header, value string) {
 func (l *Lambda) TraceID() string {
 	return l.Trace.TraceID()
 }
+
+// AddLambdaToContext will return the context with value of Lambda
+func AddLambdaToContext(ctx context.Context, l *Lambda) context.Context {
+	return context.WithValue(ctx, ctxName, l)
+}

--- a/lambda_test.go
+++ b/lambda_test.go
@@ -175,6 +175,8 @@ func TestContext(t *testing.T) {
 		assert.Equal("42", L(ctx).ResponseHeader().Get("Request-Path-Id"))
 		assert.Equal("ss", resp.S)
 		assert.Equal(4, resp.I)
+		otherCtx := AddLambda(context.Background(), L(ctx))
+		assert.Equal(L(ctx), L(otherCtx))
 	}
 }
 


### PR DESCRIPTION
When a goroutine created the original context can be used, because it maybe end sooner, than new goroutine can sen out the requests. So new context is created for that, but that one not contains the tracingData. So Lambda should be inserted to the new context.