### PR TITLE
Clonebody, NewErrorWithBody

### DIFF
--- a/client.go
+++ b/client.go
@@ -766,7 +766,7 @@ func (c *Client) SendRecv2xx(ctx context.Context, method string, target string, 
 				return nil, NewError(nil, resp.StatusCode, detail)
 			}
 		} else if errors.Is(err, ErrUnexpectedContentType) { // Non-problem JSON, e.g. plain text or other JSON
-			return nil, newErrorWithBody(nil, resp.StatusCode, resp.Header.Get(ContentTypeHeader), body)
+			return nil, NewErrorWithBody(nil, resp.StatusCode, resp.Header.Get(ContentTypeHeader), body)
 		}
 		return nil, NewError(fmt.Errorf("unexpected response: %s", resp.Status), resp.StatusCode, detail)
 	}

--- a/doc/lambda.md
+++ b/doc/lambda.md
@@ -38,7 +38,6 @@ import (
     "fmt"
     "net/http"
 
-    "github.com/go-playground/validator/v10"
     "github.com/google/uuid"
     "github.com/nokia/restful"
     "github.com/sirupsen/logrus"

--- a/error.go
+++ b/error.go
@@ -97,7 +97,8 @@ func NewError(err error, statusCode int, description ...string) error {
 	return &restError{err: err, statusCode: statusCode, problemDetails: ProblemDetails{Detail: strings.Join(description, " ")}}
 }
 
-func newErrorWithBody(err error, statusCode int, contentType string, body []byte) error {
+// NewErrorWithBody creates new error with custom HTTP status code, content-type and payload body.
+func NewErrorWithBody(err error, statusCode int, contentType string, body []byte) error {
 	if len(body) > maxErrBodyLen {
 		return &restError{err: err, statusCode: statusCode}
 	}


### PR DESCRIPTION
* Retry: cloneBody() refactor.
* NewErrorWithBody creates new error with custom HTTP status code, content-type and payload body.