### PR TITLE
If data is not struct, then don't validate as struct

### DIFF
--- a/mux_lambda_wrapper.go
+++ b/mux_lambda_wrapper.go
@@ -116,7 +116,7 @@ func lambdaGetParams(w http.ResponseWriter, r *http.Request, f any) ([]reflect.V
 				return nil, r, err
 			}
 
-			if LambdaValidator {
+			if LambdaValidator && reflect.ValueOf(reqDataInterface).Elem().Kind() == reflect.Struct {
 				if err := validate.Struct(reqDataInterface); err != nil {
 					return nil, r, NewError(err, http.StatusUnprocessableEntity)
 				}


### PR DESCRIPTION
In some cases the 3gpp standard defined that the incoming json is a array of structs. In that case it can't be validate as struct.