### PR TITLE
PostFormWithFullResponse

### DIFF
--- a/client.go
+++ b/client.go
@@ -885,7 +885,7 @@ func (c *Client) PostForm(ctx context.Context, target string, reqData url.Values
 
 // PostFormWithFullResponse posts data as "application/x-www-form-urlencoded".
 // Returns the full response.
-func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values, cookies map[string]string, headers map[string]string) (*http.Response, error) {
+func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values, cookies *[]http.Cookie, headers *http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader(reqData.Encode()))
 	if err != nil {
 		return nil, err
@@ -893,15 +893,17 @@ func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, re
 
 	req.Header.Set("Content-Type", ContentTypeForm)
 
-	if headers != nil {
-		for name, value := range headers {
-			req.Header.Set(name, value)
+	if cookies != nil {
+		for _, cookie := range *cookies {
+			req.AddCookie(&cookie)
 		}
 	}
 
-	if cookies != nil {
-		for name, value := range cookies {
-			req.AddCookie(&http.Cookie{Name: name, Value: value})
+	if headers != nil {
+		for key, values := range *headers {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -883,6 +883,24 @@ func (c *Client) PostForm(ctx context.Context, target string, reqData url.Values
 	return location, nil
 }
 
+// PostFormWithFullResponse posts data as "application/x-www-form-urlencoded".
+// Returns the full response.
+func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader(reqData.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", ContentTypeForm)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 // Post sends a POST request.
 // Primarily designed to create a resource and return its Location. That may be nil.
 func (c *Client) Post(ctx context.Context, target string, reqData, respData any) (*url.URL, error) {

--- a/client.go
+++ b/client.go
@@ -885,13 +885,25 @@ func (c *Client) PostForm(ctx context.Context, target string, reqData url.Values
 
 // PostFormWithFullResponse posts data as "application/x-www-form-urlencoded".
 // Returns the full response.
-func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values) (*http.Response, error) {
+func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values, cookies map[string]string, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader(reqData.Encode()))
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Set("Content-Type", ContentTypeForm)
+
+	if headers != nil {
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
+	}
+
+	if cookies != nil {
+		for name, value := range cookies {
+			req.AddCookie(&http.Cookie{Name: name, Value: value})
+		}
+	}
 
 	resp, err := c.Do(req)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -885,7 +885,7 @@ func (c *Client) PostForm(ctx context.Context, target string, reqData url.Values
 
 // PostFormWithFullResponse posts data as "application/x-www-form-urlencoded".
 // Returns the full response.
-func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values, cookies *[]http.Cookie, headers *http.Header) (*http.Response, error) {
+func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, reqData url.Values, cookies []*http.Cookie, headers *http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, strings.NewReader(reqData.Encode()))
 	if err != nil {
 		return nil, err
@@ -893,10 +893,8 @@ func (c *Client) PostFormWithFullResponse(ctx context.Context, target string, re
 
 	req.Header.Set("Content-Type", ContentTypeForm)
 
-	if cookies != nil {
-		for _, cookie := range *cookies {
-			req.AddCookie(&cookie)
-		}
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
 	}
 
 	if headers != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -229,7 +229,7 @@ func TestMethods(t *testing.T) {
 
 	v = url.Values{}
 	v.Set("Str", "b")
-	resp, err := client.PostFormWithFullResponse(ctx, "/users", v)
+	resp, err := client.PostFormWithFullResponse(ctx, "/users", v, nil, nil)
 	assert.NoError(err)
 	err = GetResponseData(resp, client.maxBytesToParse, &respData)
 	assert.NoError(err)

--- a/client_test.go
+++ b/client_test.go
@@ -227,6 +227,15 @@ func TestMethods(t *testing.T) {
 	assert.NoError(err)
 	assert.EqualValues(reqData, respData)
 
+	v = url.Values{}
+	v.Set("Str", "b")
+	resp, err := client.PostFormWithFullResponse(ctx, "/users", v)
+	assert.NoError(err)
+	err = GetResponseData(resp, client.maxBytesToParse, &respData)
+	assert.NoError(err)
+	assert.NotNil(resp)
+	assert.EqualValues(reqData, respData)
+
 	err = client.Delete(ctx, locationStr)
 	assert.Nil(err)
 	err = Delete(ctx, locationStr)
@@ -865,56 +874,56 @@ func TestCientInterface(t *testing.T) {
 func startH2Server(mux *http.ServeMux, wg *sync.WaitGroup) *http.Server {
 	defer wg.Done()
 	server := &http.Server{
-        Addr:    "localhost:8443",
-        Handler: mux,
-        TLSConfig: &tls.Config{
-            NextProtos: []string{"h2"},
-        },
-    }
+		Addr:    "localhost:8443",
+		Handler: mux,
+		TLSConfig: &tls.Config{
+			NextProtos: []string{"h2"},
+		},
+	}
 
-    go func() {
-        if err := server.ListenAndServeTLS("test_certs/tls.crt", "test_certs/tls.key"); err != nil && err != http.ErrServerClosed {
-            fmt.Printf("Failed to start server: %v", err)
-        }
-    }()
+	go func() {
+		if err := server.ListenAndServeTLS("test_certs/tls.crt", "test_certs/tls.key"); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("Failed to start server: %v", err)
+		}
+	}()
 	return server
 }
 
 func startH2CServer(mux *http.ServeMux, wg *sync.WaitGroup) *http.Server {
 	defer wg.Done()
 	server := &http.Server{
-        Addr:    "localhost:8440",
-        Handler: h2c.NewHandler(mux, &http2.Server{}),
-    }
+		Addr:    "localhost:8440",
+		Handler: h2c.NewHandler(mux, &http2.Server{}),
+	}
 
-    go func() {
-        if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-            fmt.Printf("Failed to start server: %v", err)
-        }
-    }()
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("Failed to start server: %v", err)
+		}
+	}()
 	return server
 }
 
 func TestClients(t *testing.T) {
 	mux := http.NewServeMux()
-    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"message": "Hello, world!"}
 		json.NewEncoder(w).Encode(response)
-    })
+	})
 	var wg sync.WaitGroup
 	wg.Add(2)
 	h2Server := startH2Server(mux, &wg)
 	h2cServer := startH2CServer(mux, &wg)
-	defer func() { 
+	defer func() {
 		h2Server.Close()
-	    h2cServer.Close()
+		h2cServer.Close()
 	}()
 
 	h2Client := NewH2Client()
-	h2Client.Client.Transport.(*http2.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true,}
+	h2Client.Client.Transport.(*http2.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	h2cClient := NewH2CClient()
-	
+
 	wg.Wait()
 
 	tests := []struct {
@@ -924,12 +933,12 @@ func TestClients(t *testing.T) {
 	}{
 		{
 			name:      "HTTP/2 Client (H2)",
-			client:     h2Client,
+			client:    h2Client,
 			serverURL: "https://localhost:8443", // H2 server
 		},
 		{
 			name:      "HTTP/2 Cleartext Client (H2C)",
-			client:     h2cClient,
+			client:    h2cClient,
 			serverURL: "http://localhost:8440", // H2C server
 		},
 	}
@@ -942,7 +951,7 @@ func TestClients(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to make request: %v", err)
 			}
-		
+
 			b, _ := json.Marshal(resp)
 			if string(b) != "{\"message\":\"Hello, world!\"}" {
 				t.Fatalf("Unexpected response: %s", b)


### PR DESCRIPTION
PostFormWithFullResponse is added to handle situations where the user needs to access the full response if the response's status is not 2xx. 