### PR TITLE
Additional TLS configuration methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -241,6 +241,7 @@ func getH2CTransport(iface string) *http2.Transport {
 func getDialTLSCallback(iface string, withTLS bool) func(string, string, *tls.Config) (net.Conn, error) {
 	return func(network, addr string, cfg *tls.Config) (net.Conn, error) {
 		dialer := net.Dialer{Timeout: 2 * time.Second}
+		cfg.NextProtos = []string{http2.NextProtoTLS}
 
 		var conn net.Conn
 		var err error
@@ -266,7 +267,6 @@ func getDialTLSCallback(iface string, withTLS bool) func(string, string, *tls.Co
 
 		// Skip TLS dial if it is the H2C
 		if withTLS {
-			cfg.NextProtos = []string{http2.NextProtoTLS}
 			if err := conn.(*tls.Conn).Handshake(); err != nil {
 				return nil, err
 			}

--- a/client.go
+++ b/client.go
@@ -266,6 +266,7 @@ func getDialTLSCallback(iface string, withTLS bool) func(string, string, *tls.Co
 
 		// Skip TLS dial if it is the H2C
 		if withTLS {
+			cfg.NextProtos = []string{http2.NextProtoTLS}
 			if err := conn.(*tls.Conn).Handshake(); err != nil {
 				return nil, err
 			}

--- a/client_tls.go
+++ b/client_tls.go
@@ -103,8 +103,9 @@ func (c *Client) haveTLSClientConfig() *tls.Config {
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{} // #nosec G402 -- false positive, see below
 	}
-
-	transport.TLSClientConfig.MinVersion = tls.VersionTLS12 // TLS 1.2 is the minimum supported.
+	if transport.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS12 // TLS 1.2 is the minimum supported.
+	}
 
 	return transport.TLSClientConfig
 }
@@ -148,7 +149,7 @@ func (c *Client) Insecure() *Client {
 // Returns:
 //   - *Client: The client instance with the updated TLS minimum version.
 func (c *Client) SetTLSMinVersion(tlsMinVersion uint16) *Client {
-	c.haveTLSClientConfig().MinVersion   = tlsMinVersion
+	c.haveTLSClientConfig().MinVersion = tlsMinVersion
 	return c
 }
 

--- a/client_tls.go
+++ b/client_tls.go
@@ -180,13 +180,3 @@ func (c *Client) SetCipherSuites(cipherSuites []uint16) *Client {
 	c.haveTLSClientConfig().CipherSuites = cipherSuites
 	return c
 }
-
-// SetALPNH2 sets the ALPN (Application-Layer Protocol Negotiation) to only support HTTP/2 (h2).
-// It returns the client instance to allow for method chaining.
-//
-// Returns:
-//   - *Client: The client instance with the updated ALPN protocols.
-func (c *Client) SetALPNH2() *Client {
-	c.haveTLSClientConfig().NextProtos = []string{"h2"}
-	return c
-}

--- a/client_tls.go
+++ b/client_tls.go
@@ -137,3 +137,55 @@ func (c *Client) Insecure() *Client {
 	c.haveTLSClientConfig().InsecureSkipVerify = true
 	return c
 }
+
+// SetTLSMinVersion sets the minimum TLS version for the client.
+// The tlsMinVersion parameter specifies the minimum version of TLS that is acceptable.
+// It returns the client instance to allow for method chaining.
+//
+// Parameters:
+//   - tlsMinVersion: The minimum TLS version to be set.
+//
+// Returns:
+//   - *Client: The client instance with the updated TLS minimum version.
+func (c *Client) SetTLSMinVersion(tlsMinVersion uint16) *Client {
+	c.haveTLSClientConfig().MinVersion   = tlsMinVersion
+	return c
+}
+
+// SetTLSMaxVersion sets the maximum TLS version for the client.
+// The tlsMaxVersion parameter specifies the maximum version of TLS that is acceptable.
+// It returns the client instance to allow for method chaining.
+//
+// Parameters:
+//   - tlsMaxVersion: The maximum TLS version to be set.
+//
+// Returns:
+//   - *Client: The client instance with the updated TLS maximum version.
+func (c *Client) SetTLSMaxVersion(tlsMaxVersion uint16) *Client {
+	c.haveTLSClientConfig().MaxVersion = tlsMaxVersion
+	return c
+}
+
+// SetCipherSuites sets the list of cipher suites for the client.
+// The cipherSuites parameter specifies the list of cipher suites to be used.
+// It returns the client instance to allow for method chaining.
+//
+// Parameters:
+//   - cipherSuites: The list of cipher suites to be set.
+//
+// Returns:
+//   - *Client: The client instance with the updated cipher suites.
+func (c *Client) SetCipherSuites(cipherSuites []uint16) *Client {
+	c.haveTLSClientConfig().CipherSuites = cipherSuites
+	return c
+}
+
+// SetALPNH2 sets the ALPN (Application-Layer Protocol Negotiation) to only support HTTP/2 (h2).
+// It returns the client instance to allow for method chaining.
+//
+// Returns:
+//   - *Client: The client instance with the updated ALPN protocols.
+func (c *Client) SetALPNH2() *Client {
+	c.haveTLSClientConfig().NextProtos = []string{"h2"}
+	return c
+}

--- a/client_tls_test.go
+++ b/client_tls_test.go
@@ -109,16 +109,6 @@ func TestAppendCert(t *testing.T) {
 	appendCert("client_tls_test.go", nil)
 }
 
-func TestSetALPNH2(t *testing.T) {
-	assert := assert.New(t)
-
-	client := NewClient()
-	client.SetALPNH2()
-
-	tlsConfig := client.haveTLSClientConfig()
-	assert.Contains(tlsConfig.NextProtos, "h2")
-}
-
 func TestSetCipherSuites(t *testing.T) {
 	assert := assert.New(t)
 

--- a/client_tls_test.go
+++ b/client_tls_test.go
@@ -108,3 +108,46 @@ func TestAppendCert(t *testing.T) {
 	appendCert("kutyafüle", nil)
 	appendCert("client_tls_test.go", nil)
 }
+
+func TestSetALPNH2(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewClient()
+	client.SetALPNH2()
+
+	tlsConfig := client.haveTLSClientConfig()
+	assert.Contains(tlsConfig.NextProtos, "h2")
+}
+
+func TestSetCipherSuites(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewClient()
+	cipherSuites := []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}
+	client.SetCipherSuites(cipherSuites)
+
+	tlsConfig := client.haveTLSClientConfig()
+	assert.Equal(cipherSuites, tlsConfig.CipherSuites)
+}
+
+func TestSetTLSMaxVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewClient()
+	maxVersion := uint16(tls.VersionTLS13)
+	client.SetTLSMaxVersion(maxVersion)
+
+	tlsConfig := client.haveTLSClientConfig()
+	assert.Equal(maxVersion, tlsConfig.MaxVersion)
+}
+
+func TestSetTLSMinVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewClient()
+	minVersion := uint16(tls.VersionTLS12)
+	client.SetTLSMinVersion(minVersion)
+
+	tlsConfig := client.haveTLSClientConfig()
+	assert.Equal(minVersion, tlsConfig.MinVersion)
+}


### PR DESCRIPTION
- Add TLS configuration methods for minimum/maximum versions and cipher suites
- Set APLN to h2 only when h2 client is used.