### PR TITLE
http2 client transport, DialTLSContext instead of deprecated DialTLS

### DIFF
--- a/client.go
+++ b/client.go
@@ -230,19 +230,19 @@ func NewH2CClientWInterface(networkInterface string) *Client {
 
 func getH2Transport(iface string) *http2.Transport {
 	return &http2.Transport{
-		DialTLS: getDialTLSCallback(iface, true),
+		DialTLSContext: getDialTLSCallback(iface, true),
 	}
 }
 
 func getH2CTransport(iface string) *http2.Transport {
 	return &http2.Transport{
 		AllowHTTP: true,
-		DialTLS:   getDialTLSCallback(iface, false),
+		DialTLSContext:   getDialTLSCallback(iface, false),
 	}
 }
 
-func getDialTLSCallback(iface string, withTLS bool) func(string, string, *tls.Config) (net.Conn, error) {
-	return func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+func getDialTLSCallback(iface string, withTLS bool) func(context.Context, string, string, *tls.Config) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
 		dialer := net.Dialer{Timeout: DialTimeout}
 
 		var conn net.Conn


### PR DESCRIPTION
In the previous [PR!83](https://github.com/nokia/restful/pull/83), the `NewH2ClientWInterface` was filled with the http2.Transport, whose DialTLS is deprecated.

`"golang.org/x/net/http2"` library says:
```go
// DialTLS specifies an optional dial function for creating
// TLS connections for requests.
//
// If DialTLSContext and DialTLS is nil, tls.Dial is used.
//
// Deprecated: Use DialTLSContext instead, which allows the transport
// to cancel dials as soon as they are no longer needed.
// If both are set, DialTLSContext takes priority.
DialTLS func(network, addr string, cfg *tls.Config) (net.Conn, error)
```

The DialTLS is replaced with the DialTLSContext in this PR. 