### PR TITLE
Validation error fix

### DIFF
--- a/mux_lambda_wrapper.go
+++ b/mux_lambda_wrapper.go
@@ -133,6 +133,9 @@ func lambdaGetParams(w http.ResponseWriter, r *http.Request, f any) ([]reflect.V
 				if err := Validate.Struct(reqDataInterface); err != nil {
 					if ValidateErrConverter != nil {
 						err = ValidateErrConverter(err)
+						if _, ok := err.(*restError); ok { // no need to wrap
+							return nil, r, err
+						}
 					}
 					return nil, r, NewError(err, LambdaValidationErrorStatus)
 				}


### PR DESCRIPTION
Validator error: Wrapping ruins the restful error the provided `ValidateErrConverter` function returned.

@csaron92 @flaszlo2 