### PR TITLE
Sampling env

### DIFF
--- a/client.go
+++ b/client.go
@@ -463,6 +463,8 @@ func traceFromContextOrRequestOrRandom(req *http.Request) (trace tracedata.Trace
 	return
 }
 
+// doSpan spans the context.
+// Note that this span is created only once, even if there are retries.
 func doSpan(req *http.Request) (*http.Request, string, func()) {
 	trace := traceFromContextOrRequestOrRandom(req)
 

--- a/client.go
+++ b/client.go
@@ -559,6 +559,42 @@ func (c *Client) setOauth2Auth(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
+func (c *Client) doSetAuth(ctx context.Context, req *http.Request) error {
+	if c.username != "" && c.oauth2.config == nil {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	if c.oauth2.config != nil {
+		if err := c.setOauth2Auth(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) doPre(req *http.Request) (*http.Response, error) {
+	for i := len(c.monitor) - 1; i >= 0; i-- {
+		if c.monitor[i].pre != nil {
+			resp, err := c.monitor[i].pre(req)
+			if resp != nil || err != nil {
+				return resp, err
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (c *Client) doPost(req *http.Request, resp *http.Response, err error) (*http.Response, error) {
+	for i := range c.monitor {
+		if c.monitor[i].post != nil {
+			newResp := c.monitor[i].post(req, resp, err)
+			if newResp != nil {
+				resp = newResp
+			}
+		}
+	}
+	return resp, err
+}
+
 // Do sends an HTTP request and returns an HTTP response.
 // All the rules of http.Client.Do() apply.
 // If URL of req is relative path then root defined at client.Root is added as prefix.
@@ -580,35 +616,18 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 	c.setUA(req)
 
-	if c.username != "" && c.oauth2.config == nil {
-		req.SetBasicAuth(c.username, c.password)
-	}
-	if c.oauth2.config != nil {
-		if err := c.setOauth2Auth(ctx, req); err != nil {
-			return nil, err
-		}
+	if err := c.doSetAuth(ctx, req); err != nil {
+		return nil, err
 	}
 
-	for i := len(c.monitor) - 1; i >= 0; i-- {
-		if c.monitor[i].pre != nil {
-			resp, err := c.monitor[i].pre(req)
-			if resp != nil || err != nil {
-				return resp, err
-			}
-		}
+	if resp, err := c.doPre(req); resp != nil || err != nil {
+		return resp, err
 	}
 
 	req, spanStr, spanEndFunc := doSpan(req)
 	resp, err := c.doLog(spanStr, req, target)
 
-	for i := range c.monitor {
-		if c.monitor[i].post != nil {
-			newResp := c.monitor[i].post(req, resp, err)
-			if newResp != nil {
-				resp = newResp
-			}
-		}
-	}
+	resp, err = c.doPost(req, resp, err)
 
 	if spanEndFunc != nil {
 		spanEndFunc()

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -19,6 +19,10 @@ When you use RESTful, you do not need to write a single line of code for tracing
 
 OTel can be activated using environment variables `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 instead of using `SetOTel` functions.
+Sampling is then set by `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` variables.
+E.g. `OTEL_TRACES_SAMPLER=parentbased_traceidratio` and `OTEL_TRACES_SAMPLER_ARG=0.01`,
+meaning that 1% of the traffic is sampled, unless the incoming request indicates that sampling is required.
+See Otel documentation for details.
 
 An example, tracing data propagated in variable `ctx`.
 

--- a/trace.go
+++ b/trace.go
@@ -25,10 +25,9 @@ func SetOTel(enabled bool, tp *sdktrace.TracerProvider) {
 // Activates trace export to the OTLP gRPC collector target address defined.
 // Port is 4317, unless defined otherwise in provided target string.
 //
-// Fraction tells the fraction of spans to report, unless parent is sampled.
-//
-//   - Less or equal 0 means no sampling, unless parent is sampled.
-//   - Greater or equal 1 means always sampled.
+// Fraction tells the fraction of spans to report, unless the parent is sampled.
+//   - Zero means no sampling.
+//   - Greater or equal 1 means sampling all the messages.
 //   - Else the sampling fraction, e.g. 0.01 for 1%.
 func SetOTelGrpc(target string, fraction float64) error {
 	return tracer.SetOTelGrpc(target, fraction)

--- a/trace/traceb3/traceb3.go
+++ b/trace/traceb3/traceb3.go
@@ -124,10 +124,10 @@ func (b3 *TraceB3) span() *TraceB3 {
 // Span spans the existing trace data and puts that into the request.
 // Returns the updated request and a trace string for logging.
 // Does not change the input trace data.
-func (b3 *TraceB3) Span(r *http.Request) (*http.Request, string) {
+func (b3 *TraceB3) Span(r *http.Request) (*http.Request, string, func()) {
 	span := b3.span()
 	span.SetHeader(r.Header)
-	return r, span.String()
+	return r, span.String(), nil
 }
 
 func (b3 *TraceB3) setHeaderSingleLine(headers http.Header) {

--- a/trace/traceb3/traceb3_test.go
+++ b/trace/traceb3/traceb3_test.go
@@ -16,7 +16,7 @@ func TestB3SingleLine(t *testing.T) {
 	assert.True(trace.IsReceived())
 	assert.Equal(trace.TraceID(), "0af7651916cd43dd8448eb211c80319c")
 	assert.Equal(trace.SpanID(), "b9c7c989f97918e1")
-	_, span := trace.Span(r)
+	_, span, _ := trace.Span(r)
 	assert.NotContains(span, "b9c7c989f97918e1")
 	assert.Contains(trace.String(), "0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1")
 
@@ -36,7 +36,7 @@ func TestB3MultiLine(t *testing.T) {
 	assert.True(trace.IsReceived())
 	assert.Equal(trace.TraceID(), "0af7651916cd43dd8448eb211c80319c")
 	assert.Equal(trace.SpanID(), "b9c7c989f97918e1")
-	_, span := trace.Span(r)
+	_, span, _ := trace.Span(r)
 	assert.NotContains(span, "b9c7c989f97918e1")
 
 	headers := http.Header{}

--- a/trace/tracedata/tracedata.go
+++ b/trace/tracedata/tracedata.go
@@ -11,9 +11,9 @@ import (
 // TraceData contains HTTP message tracing data of various kind.
 type TraceData interface {
 	// Span spans the existing trace data and puts that into the request.
-	// Returns the updated request and a trace string for logging.
+	// Returns the updated request, a trace string for logging and a span end function or nil.
 	// Does not change the input trace data.
-	Span(r *http.Request) (*http.Request, string)
+	Span(r *http.Request) (*http.Request, string, func())
 
 	// SetHeader sets request headers according to the trace data.
 	// Input headers object must not be nil.

--- a/trace/traceotel/traceotel.go
+++ b/trace/traceotel/traceotel.go
@@ -10,12 +10,26 @@ import (
 
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var tracer trace.Tracer
+
+// spanRequestAttributes adds attributes similar to what OTel adds at transport layer.
+// But this span envelopes all the retries of the client.
+func spanRequestAttributes(r *http.Request) []attribute.KeyValue {
+	kv := []attribute.KeyValue{
+		attribute.String("http.method", r.Method),
+		attribute.String("http.url", r.URL.String()),
+	}
+	if r.ContentLength > 0 {
+		kv = append(kv, attribute.Int64("http.request.content_length", r.ContentLength))
+	}
+	return kv
+}
 
 // SetTraceProvider sets global Open Telemetry trace provider to be used.
 func SetTraceProvider(tp *sdktrace.TracerProvider) {
@@ -59,7 +73,7 @@ func NewFromContext(ctx context.Context) *TraceOTel {
 func NewRandom() *TraceOTel {
 	var span trace.Span
 	ctx, span := tracer.Start(context.Background(), "client")
-	span.End()
+	span.End() // TODO: Cretaing a span and ending that instantly is not the best way to do this.
 	return &TraceOTel{ctx: ctx}
 }
 
@@ -89,7 +103,8 @@ func (t *TraceOTel) Span(r *http.Request) (*http.Request, string, func()) {
 
 	var spanEndFunc func()
 	if spanCtx.IsValid() {
-		ctx, span := tracer.Start(ctx, "client")
+		ctx, span := tracer.Start(ctx, "HTTP "+r.Method)
+		span.SetAttributes(spanRequestAttributes(r)...)
 		spanCtx = span.SpanContext()
 		spanEndFunc = func() { span.End() }
 		r = r.WithContext(ctx)

--- a/trace/traceparent/traceparent.go
+++ b/trace/traceparent/traceparent.go
@@ -53,10 +53,10 @@ func (p *TraceParent) span() *TraceParent {
 // Span spans the existing trace data and puts that into the request.
 // Returns the updated request and a trace string for logging.
 // Does not change the input trace data.
-func (p *TraceParent) Span(r *http.Request) (*http.Request, string) {
+func (p *TraceParent) Span(r *http.Request) (*http.Request, string, func()) {
 	span := p.span()
 	span.SetHeader(r.Header)
-	return r, span.String()
+	return r, span.String(), nil
 }
 
 // SetHeader sets request headers according to the trace data.

--- a/trace/traceparent/traceparent_test.go
+++ b/trace/traceparent/traceparent_test.go
@@ -16,7 +16,7 @@ func TestParent(t *testing.T) {
 	assert.True(trace.IsReceived())
 	assert.Equal(trace.TraceID(), "0af7651916cd43dd8448eb211c80319c")
 	assert.Equal(trace.SpanID(), "b9c7c989f97918e1")
-	_, span := trace.Span(r)
+	_, span, _ := trace.Span(r)
 	assert.NotContains(span, "b9c7c989f97918e1")
 	assert.Contains(trace.String(), "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1")
 

--- a/trace/tracer/tracer.go
+++ b/trace/tracer/tracer.go
@@ -67,7 +67,6 @@ func SetOTel(enabled bool, tp *sdktrace.TracerProvider) {
 			tp = sdktrace.NewTracerProvider()
 		}
 		traceotel.SetTraceProvider(tp)
-		otel.SetTracerProvider(tp)
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, b3.New(), b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader))))
 	}
 }

--- a/trace/tracer/tracer.go
+++ b/trace/tracer/tracer.go
@@ -181,7 +181,7 @@ func NewRandom() *Tracer {
 // Span spans the existing trace data and puts that into the request.
 // Returns the updated request and a trace string for logging.
 // Does not change the input trace data.
-func (t *Tracer) Span(r *http.Request) (*http.Request, string) {
+func (t *Tracer) Span(r *http.Request) (*http.Request, string, func()) {
 	return t.traceData.Span(r)
 }
 


### PR DESCRIPTION
* Use OTEL_ environment variables properly, including sampler parameters. Automatically starting tracing.
* Client not to create and end span instantly. Fixing https://github.com/nokia/restful/issues/82.
* A bit of refactoring of `client.Do()`.