### PR TITLE
do not check on 0 body length

### DIFF
--- a/data.go
+++ b/data.go
@@ -107,12 +107,6 @@ func getData(ctx context.Context, headers http.Header, ioBody io.ReadCloser, max
 		}
 		return err
 	}
-	if len(body) == 0 {
-		if request {
-			return NewError(nil, http.StatusBadRequest, "body expected")
-		}
-		return nil
-	}
 
 	recvdContentType := GetBaseContentType(headers)
 	if isMsgPackContentType(recvdContentType) {

--- a/data.go
+++ b/data.go
@@ -108,6 +108,10 @@ func getData(ctx context.Context, headers http.Header, ioBody io.ReadCloser, max
 		return err
 	}
 
+	if len(body) == 0 {
+		return nil
+	}
+
 	recvdContentType := GetBaseContentType(headers)
 	if isMsgPackContentType(recvdContentType) {
 		err = messagepack.Unmarshal(body, data)


### PR DESCRIPTION
Some APIs enable empty - but not nil - body in the request, restful did not consider this valid.