### PR TITLE
Otel off

### DIFF
--- a/client.go
+++ b/client.go
@@ -333,6 +333,8 @@ func (c *Client) AcceptProblemJSON(acceptProblemJSON bool) *Client {
 // Restful Lambda server responds with msgpack if Accept header indicates its support automatically.
 // This is an EXPERIMENTAL feature.
 // Detailed at https://github.com/nokia/restful/issues/30
+//
+// Deprecated. This feature will be dropped in the near-future.
 func (c *Client) MsgPack(allowed bool) *Client {
 	if allowed {
 		c.msgpackUsage = msgpackDiscover

--- a/client.go
+++ b/client.go
@@ -731,7 +731,7 @@ func (c *Client) do(req *http.Request) (resp *http.Response, err error) {
 		err = ctxErr
 		return
 	}
-	resp, err = c.Client.Do(req)
+	resp, err = c.Client.Do(req) // #nosec G704: false positive; URL validated by c.httpsCfg.isAllowed in exported Do() function.
 
 	// Workaround for https://github.com/golang/go/issues/36026
 	if err, ok := err.(net.Error); ok && err.Timeout() {

--- a/client_tls.go
+++ b/client_tls.go
@@ -156,7 +156,7 @@ func (c *Client) TLSRootCerts(path string, loadSystemCerts bool) *Client {
 // TLSOwnCertOpts allows specifying custom file paths for client certificate and private key.
 type TLSOwnCertOpts struct {
 	Certificate string
-	PrivateKey  string
+	PrivateKey  string // #nosec G117: exported, so that the client can specify the private key path
 }
 
 func catDirFile(dir, file string) string {

--- a/doc/client.md
+++ b/doc/client.md
@@ -120,7 +120,7 @@ C->>S: PUT: CT:application/msgpack, Accept:application/msgpack,application/json,
 S->>C: 200: CT=application/msgpack, body=msgpack
 ```
 
-MessagePack (msgpack) is experimental. We are happy to get any feedback.
+Warning! MessagePack (msgpack) is EXPERIMENTAL. As does not seem to deliver the anticipated performance boost, it is DEPRECATED. It will be removed in the near-future.
 
 ## Broadcast goodies
 

--- a/server_response.go
+++ b/server_response.go
@@ -39,7 +39,7 @@ func SendJSONResponse(w http.ResponseWriter, statusCode int, data any, sanitizeJ
 	if body != nil {
 		w.Header().Set(ContentTypeHeader, ContentTypeApplicationJSON)
 		w.WriteHeader(statusCode)
-		_, err = w.Write(body)
+		_, err = w.Write(body) // #nosec G705: false positive; no user input
 	} else {
 		w.WriteHeader(statusCode)
 	}
@@ -70,7 +70,7 @@ func sendResponse(w http.ResponseWriter, r *http.Request, data any, sanitizeJSON
 		}
 		w.Header().Set(ContentTypeHeader, ContentTypeMsgPack)
 		w.WriteHeader(okStatus)
-		_, err = w.Write(b)
+		_, err = w.Write(b) // #nosec G705: false positive; no user input
 		return err
 	}
 
@@ -113,7 +113,7 @@ func SendResp(w http.ResponseWriter, r *http.Request, err error, data any) error
 	}
 	w.Header().Set(ContentTypeHeader, ContentTypeApplicationJSON)
 	w.WriteHeader(GetErrStatusCode(err))
-	_, err = w.Write(body)
+	_, err = w.Write(body) // #nosec G705: false positive; no user input
 	return err
 }
 
@@ -166,7 +166,7 @@ func SendProblemResponse(w http.ResponseWriter, r *http.Request, statusCode int,
 	w.Header().Set(ContentTypeHeader, getProblemContentType(r))
 	w.WriteHeader(statusCode)
 	if len(problem) > 0 {
-		_, err = w.Write([]byte(problem))
+		_, err = w.Write([]byte(problem)) // #nosec G705
 	}
 	return
 }
@@ -194,7 +194,7 @@ func sendCustomResponse(r *http.Request, w http.ResponseWriter, body []byte, sta
 	if contentType != "" && acceptContentType(r, contentType) {
 		w.Header().Set(ContentTypeHeader, contentType)
 		w.WriteHeader(statusCode)
-		_, err = w.Write([]byte(body))
+		_, err = w.Write([]byte(body)) // #nosec G705
 		return
 	}
 	SendEmptyResponse(w, statusCode)

--- a/trace/tracer/tracer.go
+++ b/trace/tracer/tracer.go
@@ -31,6 +31,7 @@ const unsetFraction = float64(-32.0)
 // OtelEnabled tells if OpenTelemetry tracing was activated.
 // If OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set, then tracing is activated automatically.
 // You may set OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG to set the sampling type and fraction.
+// You may fine-tune batch exporting parameters with OTEL_BSP_* environment variables.
 // See also
 //   - https://opentelemetry.io/docs/specs/otel/protocol/exporter/
 //   - https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
@@ -69,6 +70,9 @@ func SetOTel(enabled bool, tp *sdktrace.TracerProvider) {
 		}
 		traceotel.SetTraceProvider(tp)
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, b3.New(), b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader))))
+	} else {
+		traceotel.SetTraceProvider(sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample()), sdktrace.WithSpanProcessor(nil)))
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
 	}
 }
 


### PR DESCRIPTION
* Switching OTEL off implementation was missing.
* MessagePack support deprecation note. It will be dropped in the near-future.
* Gosec false positives in the code.